### PR TITLE
Add Atlantis on Google Cloud Run reference code

### DIFF
--- a/atlantis-on-cloud-run/atlantis.tf
+++ b/atlantis-on-cloud-run/atlantis.tf
@@ -1,0 +1,258 @@
+locals {
+  atlantis_domain = "atlantis.acme.org"
+}
+
+# Enables the IAP service for the project
+resource "google_project_service_identity" "iap" {
+  provider = google-beta
+  service  = "iap.googleapis.com"
+  project  = local.project_id
+}
+
+# This grants the platform-engineers group access to IAP so they can access the Atlantis UI
+resource "google_project_iam_member" "gcp_platform_engineers_iap_https_resource_accessor" {
+  project = local.project_id
+  role    = "roles/iap.httpsResourceAccessor"
+  member  = "group:platform-engineers@acme.org"
+}
+
+# Redis is used by the different Atlantis instances to read and write locks
+resource "google_redis_instance" "atlantis" {
+  name               = "atlantis"
+  tier               = "STANDARD_HA"
+  redis_version      = "REDIS_7_2"
+  memory_size_gb     = 1
+  region             = "europe-west4"
+  authorized_network = google_compute_network.example.name
+  connect_mode       = "PRIVATE_SERVICE_ACCESS"
+  # RDB is important to enable, as it ensures Atlantis lock data is not lost on failover or restarts
+  persistence_config {
+    persistence_mode    = "RDB"
+    rdb_snapshot_period = "TWENTY_FOUR_HOURS"
+  }
+  maintenance_policy {
+    weekly_maintenance_window {
+      day = "TUESDAY"
+      start_time {
+        hours   = 0
+        minutes = 30
+        seconds = 0
+        nanos   = 0
+      }
+    }
+  }
+  project = local.project_id
+  lifecycle {
+    prevent_destroy = true
+  }
+  depends_on = [
+    # Dependecy you need to add, or completely remove Private Service Access.
+    google_service_networking_connection.service_networking,
+  ]
+}
+
+# Remote Artifact Registry for GitHub Container Registry,
+# allowing Cloud Run to the runatlantis/atlantis image from GHCR
+resource "google_artifact_registry_repository" "ghcr" {
+  repository_id = "ghcr"
+  format        = "DOCKER"
+  location      = "europe-west4"
+  mode          = "REMOTE_REPOSITORY"
+  description   = "Proxy to GitHub Container Registry"
+  remote_repository_config {
+    common_repository {
+      uri = "https://ghcr.io"
+    }
+  }
+  project = local.project_id
+}
+
+# Replace this with GitHub, or BitBucket if you use that
+resource "google_secret_manager_secret" "atlantis_gitlab_token" {
+  secret_id = "atlantis-gitlab-token"
+  replication {
+    user_managed {
+      replicas {
+        location = "europe-west4"
+      }
+      replicas {
+        location = "europe-west1"
+      }
+    }
+  }
+  deletion_protection = true
+  project             = local.project_id
+}
+
+resource "google_secret_manager_secret" "atlantis_webhook" {
+  secret_id = "atlantis-webhook"
+  replication {
+    user_managed {
+      replicas {
+        location = "europe-west4"
+      }
+      replicas {
+        location = "europe-west1"
+      }
+    }
+  }
+  deletion_protection = true
+  project             = local.project_id
+}
+
+# Generate a random webhook secret for Atlantis, to protect the /events endpoint with
+ephemeral "random_password" "atlantis_webhook" {
+  length  = 16
+  special = false
+}
+
+# Write the ephemeral secret to Secret Manager, the `secret_data_wo` does not persist in state
+resource "google_secret_manager_secret_version" "atlantis_webhook" {
+  secret                 = google_secret_manager_secret.atlantis_webhook.id
+  secret_data_wo         = ephemeral.random_password.atlantis_webhook.result
+  secret_data_wo_version = 1
+}
+
+### Below we're creating a single shared External HTTP(S) Load Balancer for all Atlantis services
+### Each Atlantis service gets its own subdomain, SSL certificate, backend service and Cloud Run service
+### The URL map, target HTTPS proxy and global forwarding rule are shared
+resource "google_compute_global_address" "atlantis" {
+  name    = "atlantis"
+  project = local.project_id
+}
+
+resource "google_compute_managed_ssl_certificate" "atlantis" {
+  provider = google-beta
+  name     = "atlantis"
+  managed {
+    domains = [local.atlantis_domain]
+  }
+  project = local.project_id
+}
+
+# To protect the Atlantis UI using Identity-Aware Proxy (IAP) we need to create an OAuth2 client ID and secret
+# These are stored in Secret Manager and referenced in the backend services below.
+# The client ID and secret need to be created manually in the Google Cloud Console
+# at https://console.cloud.google.com/apis/credentials
+resource "google_secret_manager_secret" "atlantis_oauth2_client_id" {
+  secret_id = "atlantis-oauth2-client-id"
+  replication {
+    user_managed {
+      replicas {
+        location = "europe-west4"
+      }
+      replicas {
+        location = "europe-west1"
+      }
+    }
+  }
+  deletion_protection = true
+  project             = local.project_id
+}
+
+data "google_secret_manager_secret_version_access" "atlantis_oauth2_client_id" {
+  secret  = google_secret_manager_secret.atlantis_oauth2_client_id.id
+  project = google_secret_manager_secret.atlantis_oauth2_client_id.project
+}
+
+resource "google_secret_manager_secret" "atlantis_oauth2_client_secret" {
+  secret_id = "atlantis-oauth2-client-secret"
+  replication {
+    user_managed {
+      replicas {
+        location = "europe-west4"
+      }
+      replicas {
+        location = "europe-west1"
+      }
+    }
+  }
+  deletion_protection = true
+  project             = local.project_id
+}
+
+data "google_secret_manager_secret_version_access" "atlantis_oauth2_client_secret" {
+  secret  = google_secret_manager_secret.atlantis_oauth2_client_secret.id
+  project = google_secret_manager_secret.atlantis_oauth2_client_secret.project
+}
+
+# This is where the load balancing magic happens, 
+## routing traffic to the correct backend service based on the hostname and path
+resource "google_compute_url_map" "atlantis" {
+  name = "atlantis"
+  default_url_redirect {
+    host_redirect          = local.atlantis_domain
+    https_redirect         = true
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+  }
+  host_rule {
+    hosts        = ["management.${local.atlantis_domain}"]
+    path_matcher = "atlantis-management-webhooks"
+  }
+  host_rule {
+    hosts        = ["network.${local.atlantis_domain}"]
+    path_matcher = "atlantis-network-webhooks"
+  }
+  host_rule {
+    # Workloads does not exist yet, but it's to give you an idea of how to scale this
+    hosts        = ["workloads.${local.atlantis_domain}"]
+    path_matcher = "atlantis-workloads-webhooks"
+  }
+  path_matcher {
+    name            = "atlantis-management-webhooks"
+    default_service = google_compute_backend_service.atlantis_management.id
+    path_rule {
+      paths   = ["/events"]
+      service = google_compute_backend_service.atlantis_management_webhooks.id
+    }
+  }
+  path_matcher {
+    name            = "atlantis-network-webhooks"
+    default_service = google_compute_backend_service.atlantis_network.id
+    path_rule {
+      paths   = ["/events"]
+      service = google_compute_backend_service.atlantis_network_webhooks.id
+    }
+  }
+  path_matcher {
+    # Workloads does not exist yet, but it's to give you an idea of how to scale this
+    name            = "atlantis-workloads-webhooks"
+    default_service = google_compute_backend_service.atlantis_workloads.id
+    path_rule {
+      paths   = ["/events"]
+      service = google_compute_backend_service.atlantis_workloads_webhooks.id
+    }
+  }
+  project = local.project_id
+}
+
+resource "google_compute_ssl_policy" "restricted" {
+  name            = "restricted"
+  profile         = "RESTRICTED"
+  min_tls_version = "TLS_1_2"
+  project         = local.project_id
+}
+
+resource "google_compute_target_https_proxy" "atlantis" {
+  name    = "atlantis"
+  url_map = google_compute_url_map.atlantis.id
+  ssl_certificates = [
+    google_compute_managed_ssl_certificate.atlantis.id,
+    google_compute_managed_ssl_certificate.atlantis_network.id,
+    google_compute_managed_ssl_certificate.atlantis_management.id,
+    # Workloads does not exist yet, but it's to give you an idea of how to scale this
+    google_compute_managed_ssl_certificate.atlantis_workloads.id,
+  ]
+  ssl_policy = google_compute_ssl_policy.restricted.id
+  project    = local.project_id
+}
+
+resource "google_compute_global_forwarding_rule" "atlantis" {
+  name                  = "atlantis"
+  target                = google_compute_target_https_proxy.atlantis.id
+  port_range            = "443"
+  ip_address            = google_compute_global_address.atlantis.address
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  project               = local.project_id
+}

--- a/atlantis-on-cloud-run/atlantis/management.yaml
+++ b/atlantis-on-cloud-run/atlantis/management.yaml
@@ -1,0 +1,17 @@
+repos:
+  - id: github.com/acme/gcp-tf-management
+    apply_requirements: [approved, mergeable]
+    import_requirements: [approved, mergeable]
+    allowed_overrides: ["workflow"]
+    allowed_workflows: ["example"]
+    delete_source_branch_on_merge: true
+
+workflows:
+  example:
+    plan:
+      steps:
+        - init
+        - plan
+    apply:
+      steps:
+        - apply

--- a/atlantis-on-cloud-run/atlantis/network.yaml
+++ b/atlantis-on-cloud-run/atlantis/network.yaml
@@ -1,0 +1,48 @@
+repos:
+  - id: gitlab.com/acme/gcp-tf-network
+    apply_requirements: [approved, mergeable]
+    import_requirements: [approved, mergeable]
+    delete_source_branch_on_merge: true
+    allowed_overrides: ["workflow"]
+    allowed_workflows: ["gcp-tf-network-dev", "gcp-tf-network-prod"]
+
+workflows:
+  gcp-tf-network-dev:
+    plan:
+      steps:
+        - env:
+            name: GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
+            value: atlantis-network-dev@acme.iam.gserviceaccount.com
+        - run: rm -rf .terraform
+        - init:
+            extra_args:
+              ["-lock=false", "-backend-config=env/dev/backend-config.tfvars"]
+        - plan:
+            extra_args: ["-lock=false", "-var-file=env/dev/vars.tfvars"]
+    apply:
+      steps:
+        - env:
+            name: GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
+            value: atlantis-network-dev@acme.iam.gserviceaccount.com
+        - apply:
+            extra_args: ["-lock=false"]
+
+  gcp-tf-network-prod:
+    plan:
+      steps:
+        - env:
+            name: GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
+            value: atlantis-network-prod@acme.iam.gserviceaccount.com
+        - run: rm -rf .terraform
+        - init:
+            extra_args:
+              ["-lock=false", "-backend-config=env/prod/backend-config.tfvars"]
+        - plan:
+            extra_args: ["-lock=false", "-var-file=env/prod/vars.tfvars"]
+    apply:
+      steps:
+        - env:
+            name: GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
+            value: atlantis-network-prod@acme.iam.gserviceaccount.com
+        - apply:
+            extra_args: ["-lock=false"]

--- a/atlantis-on-cloud-run/atlantis_management.tf
+++ b/atlantis-on-cloud-run/atlantis_management.tf
@@ -1,0 +1,230 @@
+resource "google_service_account" "atlantis_management" {
+  account_id = "atlantis-management"
+  project    = local.project_id
+}
+
+resource "google_project_iam_member" "atlantis_management_owner" {
+  member  = "serviceAccount:${google_service_account.atlantis_management.email}"
+  project = local.project_id
+  role    = "roles/owner"
+}
+
+# Grant the Atlantis Management service account permission to read/write Terraform state
+# in the shared Terraform state bucket.
+# Note: For brevity in this example, we grant full object access here. In practice,
+# it's better to restrict access to specific prefixes!
+resource "google_storage_bucket_iam_member" "atlantis_management_terraform_state_object_admin" {
+  bucket = data.google_storage_bucket.terraform_state.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.atlantis_management.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "atlantis_gitlab_token_atlantis_management_secret_accessor" {
+  secret_id = google_secret_manager_secret.atlantis_gitlab_token.secret_id
+  project   = google_secret_manager_secret.atlantis_gitlab_token.project
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.atlantis_management.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "atlantis_webhook_atlantis_management_secret_accessor" {
+  secret_id = google_secret_manager_secret.atlantis_webhook.secret_id
+  project   = google_secret_manager_secret.atlantis_webhook.project
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.atlantis_management.email}"
+}
+
+resource "google_artifact_registry_repository_iam_member" "ghcr_management_atlantis_registry_reader" {
+  project    = google_artifact_registry_repository.ghcr.project
+  location   = google_artifact_registry_repository.ghcr.location
+  repository = google_artifact_registry_repository.ghcr.name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.atlantis_network.email}"
+}
+
+resource "google_cloud_run_v2_service" "atlantis_management" {
+  provider             = google-beta
+  name                 = "atlantis-management"
+  location             = "europe-west4"
+  deletion_protection  = false
+  ingress              = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  invoker_iam_disabled = true
+  launch_stage         = "GA"
+
+  template {
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 1
+    }
+    execution_environment = "EXECUTION_ENVIRONMENT_GEN2"
+    service_account       = google_service_account.atlantis_management.email
+    containers {
+      image = "europe-west4-docker.pkg.dev/${local.project_id}/ghcr/runatlantis/atlantis:v0.35.1"
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "2Gi"
+        }
+      }
+      volume_mounts {
+        name       = "atlantis"
+        mount_path = "/app/atlantis"
+      }
+      env {
+        name  = "ATLANTIS_PORT"
+        value = "8080"
+      }
+      env {
+        name  = "ATLANTIS_DATA_DIR"
+        value = "/app/atlantis"
+      }
+      env {
+        name  = "ATLANTIS_USE_TF_PLUGIN_CACHE"
+        value = "true"
+      }
+      env {
+        name  = "ATLANTIS_DISCARD_APPROVAL_ON_PLAN"
+        value = "true"
+      }
+      env {
+        name  = "ATLANTIS_HIDE_PREV_PLAN_COMMENTS"
+        value = "true"
+      }
+      env {
+        name  = "ATLANTIS_HIDE_UNCHANGED_PLAN_COMMENTS"
+        value = "true"
+      }
+      env {
+        name  = "ATLANTIS_EMOJI_REACTION"
+        value = "eyes"
+      }
+      env {
+        name  = "ATLANTIS_CHECKOUT_STRATEGY"
+        value = "merge"
+      }
+      env {
+        name  = "ATLANTIS_WRITE_GIT_CREDS"
+        value = "true"
+      }
+      env {
+        name  = "ATLANTIS_GITLAB_USER"
+        value = "acme-org-atlantis"
+      }
+      env {
+        name = "ATLANTIS_GITLAB_TOKEN"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.atlantis_gitlab_token.id
+            version = "latest"
+          }
+        }
+      }
+      env {
+        name = "ATLANTIS_GITLAB_WEBHOOK_SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.atlantis_webhook.id
+            version = "latest"
+          }
+        }
+      }
+      env {
+        name  = "ATLANTIS_LOCKING_DB_TYPE"
+        value = "redis"
+      }
+      env {
+        name  = "ATLANTIS_REDIS_HOST"
+        value = google_redis_instance.atlantis.host
+      }
+      env {
+        name  = "ATLANTIS_REDIS_DB"
+        value = "0"
+      }
+      env {
+        name  = "ATLANTIS_REDIS_INSECURE_SKIP_VERIFY"
+        value = "true"
+      }
+      env {
+        name  = "ATLANTIS_ATLANTIS_URL"
+        value = "https://${local.atlantis_domain}"
+      }
+      env {
+        name  = "ATLANTIS_REPO_CONFIG_JSON"
+        value = jsonencode(yamldecode(file("${path.module}/atlantis/management.yaml")))
+      }
+    }
+    vpc_access {
+      egress = "ALL_TRAFFIC"
+      network_interfaces {
+        network    = google_compute_network.example.name
+        subnetwork = google_compute_subnetwork.example.name
+        tags       = ["atlantis"]
+      }
+    }
+    volumes {
+      name = "atlantis"
+      empty_dir {
+        medium     = "MEMORY"
+        size_limit = "5Gi"
+      }
+    }
+  }
+  project = local.project_id
+}
+
+resource "google_compute_managed_ssl_certificate" "atlantis_management" {
+  provider = google-beta
+  name     = "atlantis-management"
+  managed {
+    domains = ["management.${local.atlantis_domain}"]
+  }
+  project = local.project_id
+}
+
+resource "google_compute_region_network_endpoint_group" "atlantis_management" {
+  name                  = "atlantis-management"
+  network_endpoint_type = "SERVERLESS"
+  region                = google_cloud_run_v2_service.atlantis_management.location
+  cloud_run {
+    service = google_cloud_run_v2_service.atlantis_management.name
+  }
+  project = local.project_id
+}
+
+resource "google_compute_backend_service" "atlantis_management" {
+  name                  = "atlantis-management"
+  protocol              = "HTTP"
+  port_name             = "http"
+  timeout_sec           = 30
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  security_policy       = google_compute_security_policy.atlantis.id
+  backend {
+    group = google_compute_region_network_endpoint_group.atlantis_management.id
+  }
+  iap {
+    enabled              = true
+    oauth2_client_id     = data.google_secret_manager_secret_version_access.atlantis_oauth2_client_id.secret_data
+    oauth2_client_secret = data.google_secret_manager_secret_version_access.atlantis_oauth2_client_secret.secret_data
+  }
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+  project = local.project_id
+}
+
+resource "google_compute_backend_service" "atlantis_management_webhooks" {
+  name                  = "atlantis-management-webhooks"
+  protocol              = "HTTP"
+  port_name             = "http"
+  timeout_sec           = 30
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  security_policy       = google_compute_security_policy.atlantis_events_webhook.id
+  backend {
+    group = google_compute_region_network_endpoint_group.atlantis_management.id
+  }
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+  project = local.project_id
+}

--- a/atlantis-on-cloud-run/atlantis_network.tf
+++ b/atlantis-on-cloud-run/atlantis_network.tf
@@ -1,0 +1,270 @@
+/*
+This file represents a single Atlantis Cloud Run instance.
+It can be replicated for other domains to host multiple 
+Atlantis instances.
+
+Make sure to update the load balancer in atlantis.tf to route
+traffic to this, and other, instances.
+*/
+
+
+## Each Atlantis instance is associated with one or more service accounts.
+## These service accounts allow Atlantis to impersonate them, granting
+## the necessary permissions to manage infrastructure in specific environments.
+##
+## In this example, we create two service accounts: one for development
+## and one for production. The base service account (declared below) 
+## can impersonate both of these accounts.
+locals {
+  atlantis_network_service_accounts = [
+    "atlantis-network-dev",
+    "atlantis-network-prod",
+  ]
+}
+
+# This service account is used by the Atlantis Cloud Run service
+# It has permissions to impersonate the service accounts declared above.
+resource "google_service_account" "atlantis_network" {
+  account_id = "atlantis-network"
+  project    = local.project_id
+}
+
+# Grant the Atlantis Network service accounts permission to read/write Terraform state
+# in the shared Terraform state bucket.
+# Note: For brevity in this example, we grant full object access here. In practice,
+# it's better to restrict access to specific prefixes!
+resource "google_storage_bucket_iam_member" "atlantis_network_terraform_state_object_admin" {
+  for_each = google_service_account.atlantis_network_service_accounts
+  bucket   = data.google_storage_bucket.terraform_state.name
+  role     = "roles/storage.objectAdmin"
+  member   = "serviceAccount:${each.value.email}"
+
+  depends_on = [
+    google_service_account.atlantis_network_service_accounts,
+  ]
+}
+
+# Create the service accounts that Atlantis can impersonate
+resource "google_service_account" "atlantis_network_service_accounts" {
+  for_each   = toset(local.atlantis_network_service_accounts)
+  account_id = each.value
+  project    = local.project_id
+}
+
+# Granting the impersonation role to the (base) Atlantis Network service account,
+resource "google_service_account_iam_member" "atlantis_network_impersonation" {
+  for_each           = google_service_account.atlantis_network_service_accounts
+  service_account_id = each.value.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.atlantis_network.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "atlantis_gitlab_token_atlantis_network_secret_accessor" {
+  secret_id = google_secret_manager_secret.atlantis_gitlab_token.secret_id
+  project   = google_secret_manager_secret.atlantis_gitlab_token.project
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.atlantis_network.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "atlantis_webhook_atlantis_network_secret_accessor" {
+  secret_id = google_secret_manager_secret.atlantis_webhook.secret_id
+  project   = google_secret_manager_secret.atlantis_webhook.project
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.atlantis_network.email}"
+}
+
+resource "google_artifact_registry_repository_iam_member" "ghcr_network_atlantis_registry_reader" {
+  project    = google_artifact_registry_repository.ghcr.project
+  location   = google_artifact_registry_repository.ghcr.location
+  repository = google_artifact_registry_repository.ghcr.name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.atlantis_network.email}"
+}
+
+resource "google_cloud_run_v2_service" "atlantis_network" {
+  provider             = google-beta
+  name                 = "atlantis-network"
+  location             = "europe-west4"
+  deletion_protection  = false
+  ingress              = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  invoker_iam_disabled = true
+  launch_stage         = "GA"
+
+  template {
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 1
+    }
+    execution_environment = "EXECUTION_ENVIRONMENT_GEN2"
+    service_account       = google_service_account.atlantis_network.email
+    containers {
+      image = "europe-west4-docker.pkg.dev/${local.project_id}/ghcr/runatlantis/atlantis:v0.35.1"
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "2Gi"
+        }
+      }
+      volume_mounts {
+        name       = "atlantis"
+        mount_path = "/app/atlantis"
+      }
+      env {
+        name  = "ATLANTIS_PORT"
+        value = "8080"
+      }
+      env {
+        name  = "ATLANTIS_DATA_DIR"
+        value = "/app/atlantis"
+      }
+      env {
+        name  = "ATLANTIS_USE_TF_PLUGIN_CACHE"
+        value = "true"
+      }
+      env {
+        name  = "ATLANTIS_DISCARD_APPROVAL_ON_PLAN"
+        value = "true"
+      }
+      env {
+        name  = "ATLANTIS_HIDE_PREV_PLAN_COMMENTS"
+        value = "true"
+      }
+      env {
+        name  = "ATLANTIS_HIDE_UNCHANGED_PLAN_COMMENTS"
+        value = "true"
+      }
+      env {
+        name  = "ATLANTIS_EMOJI_REACTION"
+        value = "eyes"
+      }
+      env {
+        name  = "ATLANTIS_CHECKOUT_STRATEGY"
+        value = "merge"
+      }
+      env {
+        name  = "ATLANTIS_WRITE_GIT_CREDS"
+        value = "true"
+      }
+      env {
+        name  = "ATLANTIS_GITLAB_USER"
+        value = "acme-org-atlantis"
+      }
+      env {
+        name = "ATLANTIS_GITLAB_TOKEN"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.atlantis_gitlab_token.id
+            version = "latest"
+          }
+        }
+      }
+      env {
+        name = "ATLANTIS_GITLAB_WEBHOOK_SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.atlantis_webhook.id
+            version = "latest"
+          }
+        }
+      }
+      env {
+        name  = "ATLANTIS_LOCKING_DB_TYPE"
+        value = "redis"
+      }
+      env {
+        name  = "ATLANTIS_REDIS_HOST"
+        value = google_redis_instance.atlantis.host
+      }
+      env {
+        name  = "ATLANTIS_REDIS_DB"
+        value = "0"
+      }
+      env {
+        name  = "ATLANTIS_REDIS_INSECURE_SKIP_VERIFY"
+        value = "true"
+      }
+      env {
+        name  = "ATLANTIS_ATLANTIS_URL"
+        value = "https://${local.atlantis_domain}"
+      }
+      env {
+        name  = "ATLANTIS_REPO_CONFIG_JSON"
+        value = jsonencode(yamldecode(file("${path.module}/atlantis/network.yaml")))
+      }
+    }
+    vpc_access {
+      egress = "ALL_TRAFFIC"
+      network_interfaces {
+        network    = google_compute_network.example.name
+        subnetwork = google_compute_subnetwork.example.name
+        tags       = ["atlantis"]
+      }
+    }
+    volumes {
+      name = "atlantis"
+      empty_dir {
+        medium     = "MEMORY"
+        size_limit = "5Gi"
+      }
+    }
+  }
+  project = local.project_id
+}
+
+resource "google_compute_managed_ssl_certificate" "atlantis_network" {
+  provider = google-beta
+  name     = "atlantis-network"
+  managed {
+    domains = ["network.${local.atlantis_domain}"]
+  }
+  project = local.project_id
+}
+
+resource "google_compute_region_network_endpoint_group" "atlantis_network" {
+  name                  = "atlantis-network"
+  network_endpoint_type = "SERVERLESS"
+  region                = google_cloud_run_v2_service.atlantis_network.location
+  cloud_run {
+    service = google_cloud_run_v2_service.atlantis_network.name
+  }
+  project = local.project_id
+}
+
+resource "google_compute_backend_service" "atlantis_network" {
+  name                  = "atlantis-network"
+  protocol              = "HTTP"
+  port_name             = "http"
+  timeout_sec           = 30
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  security_policy       = google_compute_security_policy.atlantis.id
+  backend {
+    group = google_compute_region_network_endpoint_group.atlantis_network.id
+  }
+  iap {
+    enabled              = true
+    oauth2_client_id     = data.google_secret_manager_secret_version_access.atlantis_oauth2_client_id.secret_data
+    oauth2_client_secret = data.google_secret_manager_secret_version_access.atlantis_oauth2_client_secret.secret_data
+  }
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+  project = local.project_id
+}
+
+resource "google_compute_backend_service" "atlantis_network_webhooks" {
+  name                  = "atlantis-network-webhooks"
+  protocol              = "HTTP"
+  port_name             = "http"
+  timeout_sec           = 30
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  security_policy       = google_compute_security_policy.atlantis_events_webhook.id
+  backend {
+    group = google_compute_region_network_endpoint_group.atlantis_network.id
+  }
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+  project = local.project_id
+}

--- a/atlantis-on-cloud-run/iam.tf
+++ b/atlantis-on-cloud-run/iam.tf
@@ -1,0 +1,4 @@
+# Retrieves the Terraform state bucket
+data "google_storage_bucket" "terraform_state" {
+  name = "${local.project_id}-tf-state"
+}

--- a/atlantis-on-cloud-run/locals.tf
+++ b/atlantis-on-cloud-run/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  project_id = "your-project"
+}

--- a/atlantis-on-cloud-run/providers.tf
+++ b/atlantis-on-cloud-run/providers.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.46.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "6.46.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "your-terraform-state-bucket"
+    prefix = "atlantis-on-cloud-run"
+  }
+}

--- a/atlantis-on-cloud-run/services.tf
+++ b/atlantis-on-cloud-run/services.tf
@@ -1,0 +1,30 @@
+data "google_project" "default" {
+  project_id = local.project_id
+}
+
+# Below APIs are required for Atlantis on Cloud Run to function properly.
+locals {
+  services = [
+    "compute.googleapis.com",
+    "redis.googleapis.com",
+    "run.googleapis.com",
+    "memorystore.googleapis.com",
+    "vpcaccess.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "iam.googleapis.com",
+    "iap.googleapis.com",
+    "storage.googleapis.com",
+    "secretmanager.googleapis.com",
+    "dns.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "networkmanagement.googleapis.com",
+    "containerscanning.googleapis.com",
+  ]
+}
+
+resource "google_project_service" "services" {
+  for_each           = toset(local.services)
+  project            = data.google_project.default.project_id
+  service            = each.value
+  disable_on_destroy = false
+}


### PR DESCRIPTION
This adds the Terraform configurations for running Atlantis on Google Cloud Run. 
It is to accompany a blog post I'm working on: https://github.com/runatlantis/atlantis/pull/5732/files